### PR TITLE
fix: implement stock validation in sales creation

### DIFF
--- a/app/api/sales/route.ts
+++ b/app/api/sales/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
-import { sales, saleItems, customers } from "@/db/schema/product-schema";
+import { sales, saleItems, customers, products, inventoryStock } from "@/db/schema/product-schema";
 import { z } from "zod";
 import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
@@ -33,8 +33,8 @@ export async function GET(req: NextRequest) {
       updatedAt: sales.updatedAt,
       customerName: customers.name, // Select customer name directly
     })
-    .from(sales)
-    .leftJoin(customers, eq(sales.customerId, customers.id)); // Join with customers table
+      .from(sales)
+      .leftJoin(customers, eq(sales.customerId, customers.id)); // Join with customers table
 
     return NextResponse.json(allSales);
   } catch (error) {
@@ -61,6 +61,26 @@ export async function POST(req: NextRequest) {
 
   const { saleItems: saleItemsData, ...saleData } = validation.data;
 
+  const requestedQuantityExceededCheck = (await Promise.all(saleItemsData.map(async (item) => {
+    const query = (await db.select().from(inventoryStock).where(eq(inventoryStock.productId, item.productId)).leftJoin(products, eq(inventoryStock.productId, products.id)))
+    if (query[0].inventory_stock.quantity < item.quantity) return {
+      productName: query[0].products?.name,
+      exceeded: true
+    }
+    return {
+      productName: query[0].products?.name,
+      exceeded: false
+    }
+  }))).filter(({ exceeded }) => exceeded)
+
+  if (requestedQuantityExceededCheck.length) {
+    const exceededProducts = requestedQuantityExceededCheck.map(({ productName }) => productName).filter(Boolean);
+    const message = exceededProducts.length === 1
+      ? `requested quantity for "${exceededProducts[0]}" exceeds available stock.`
+      : `requested quantities for the following products exceed available stock: ${exceededProducts.join(", ")}.`;
+    return NextResponse.json({ message }, { status: 400 });
+  }
+
   try {
     const newSale = await db.transaction(async (tx) => {
       const [insertedSale] = await tx
@@ -74,7 +94,7 @@ export async function POST(req: NextRequest) {
           paymentStatus: saleData.paymentStatus,
           status: saleData.status,
           createdBy: session.user.id,
-          createdAt: new Date(), 
+          createdAt: new Date(),
           taxAmount: saleData.taxAmount.toString(),
           includeTax: saleData.includeTax,
         })
@@ -86,16 +106,28 @@ export async function POST(req: NextRequest) {
         saleId,
         productId: item.productId,
         quantity: item.quantity,
-        unitPrice: item.unitPrice.toString(), 
-        total: item.total.toString(), 
+        unitPrice: item.unitPrice.toString(),
+        total: item.total.toString(),
       }));
+
+      await Promise.all(
+        newSaleItems.map((item) =>
+          tx
+            .update(inventoryStock)
+            .set({
+              quantity: sql`${inventoryStock.quantity} - ${item.quantity}`,
+              lastUpdatedAt: new Date(),
+            })
+            .where(eq(inventoryStock.productId, item.productId))
+        )
+      );
 
       await tx.insert(saleItems).values(newSaleItems);
 
-      return insertedSale; 
+      return insertedSale;
     });
 
-    return NextResponse.json(newSale, { status: 201 }); 
+    return NextResponse.json(newSale, { status: 201 });
   } catch (error) {
     console.error("Error creating sale:", error);
     return NextResponse.json(


### PR DESCRIPTION
The stock wasn't updated correctly on sale, and the api endpoint wasn't checking whether the requested quantity is more than what was available in the stock 
this pr fixes those issues and also disabled plus to prevent the user from adding more than the available quantity 